### PR TITLE
Fix spec just for new session

### DIFF
--- a/spec/tensorflow_spec.cr
+++ b/spec/tensorflow_spec.cr
@@ -1,9 +1,11 @@
 require "./spec_helper"
 
-describe Tensorflow do
-  # TODO: Write tests
-
-  it "works" do
-    false.should eq(true)
+describe "LibTensorflow" do
+  it "initializes session" do
+    opts    = LibTensorflow.new_session_options
+    status  = LibTensorflow.new_status
+    graph   = LibTensorflow.new_graph
+    session = LibTensorflow.new_session(graph, opts, status)
+    LibTensorflow.get_code(status).should eq(LibTensorflow::Code::Ok)
   end
 end


### PR DESCRIPTION
I'd like to check whether `libtensorflow.so` has been successfully installed or not in spec.

Thanks.